### PR TITLE
Show Export OFX button only for Open Bills

### DIFF
--- a/extrato-nubank.js
+++ b/extrato-nubank.js
@@ -39,7 +39,7 @@ NEWFILEUID:NONE
           <DTSTART>${from}</DTSTART>
           <DTEND>${to}</DTEND>`;
           }
-        
+
           function endOfx() {
             return `
         </BANKTRANLIST>
@@ -47,7 +47,7 @@ NEWFILEUID:NONE
     </STMTTRNRS>
   </BANKMSGSRSV1>
 </OFX>`;
-    
+
   }
 
   function bankStatement(date, amount, description) {
@@ -91,7 +91,7 @@ NEWFILEUID:NONE
     var dateArray = date.split(' ');
     if (dateArray.length > 2) {
       return '20'+dateArray[2];
-    } else { 
+    } else {
       return new Date().getFullYear();
     };
   }
@@ -113,15 +113,20 @@ NEWFILEUID:NONE
 
     ofx += endOfx();
 
+    var openMonth = " " + $($.find('md-tab.ng-scope.active .period')[0]).text().trim();
+    var fileName= normalizeYear(openMonth) + "-" + normalizeMonth(openMonth);
     link = document.createElement("a");
     link.setAttribute("href", 'data:application/x-ofx,'+encodeURIComponent(ofx));
-    link.setAttribute("download", "fatura-nubank.ofx");
-    link.click();      
+    link.setAttribute("download", "nubank-" + fileName + ".ofx");
+    link.click();
   }
 
-  $(document).on('DOMNodeInserted', '.summary .nu-button:contains(Gerar boleto)', function () {
-    $('<button class="nu-button secondary" role="gen-ofx">Exportar OFX</button>')
-    .insertAfter('.summary .nu-button')
+  $(document).on('DOMNodeInserted', ".summary .nu-button:not(:contains('OFX'))", function (e) {
+    if($(".summary.open [role=\"gen-ofx\"]").length > 0) {
+      return;
+    }
+    $('<button class="nu-button secondary" role="gen-ofx">Exportar para OFX</button>')
+    .insertAfter('.summary.open .nu-button')
     .click(generateOfx);
   });
 });

--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,7 @@
            "48": "nubank-ofx-48.png",
           "128": "nubank-ofx-128.png" },
   "content_scripts": [{
-    "matches": ["https://conta.nubank.com.br/*"],
+    "matches": ["https://app.nubank.com.br/*"],
     "js": ["jquery-3.0.0.min.js", "extrato-nubank.js"]
   }]
 }


### PR DESCRIPTION
After NuBank interface was updated and they added Export to OFX button
only for closed bills the code is not relevant, but opened bills doesn't
have the button.

Now, this libary is to add Export to OFX button only for opened bill.